### PR TITLE
Update foundry-js 0.18.0 → 0.20.0

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@crowdstrike/foundry-js": "https://assets.foundry.crowdstrike.com/foundry-js@0.18.0/index.js"
+          "@crowdstrike/foundry-js": "https://assets.foundry.crowdstrike.com/foundry-js@0.20.0/index.js"
         }
       }
     </script>


### PR DESCRIPTION
Updates the foundry-js CDN import from 0.18.0 to 0.20.0 in the importmap.